### PR TITLE
Update CodeMirror to 5.40.0 with Sublime keyMap to enable CTRL + / comments

### DIFF
--- a/src/UI Macros/snd_xplore_main.html
+++ b/src/UI Macros/snd_xplore_main.html
@@ -21,8 +21,11 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
 
-    <!-- CodeMirror -->
-    <link rel="stylesheet" href="/codemirror.css" />
+    <!-- CodeMirror - native CSS in ServiceNow-->
+    <!--<link rel="stylesheet" href="/codemirror.css" />-->
+
+    <!--CodeMirror Update-->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.40.0/codemirror.css" />
 
     <!-- snd_xplore -->
     <link href="/efd550a80f2a020094f3c09ce1050ecf.cssdbx" rel="stylesheet" />
@@ -475,8 +478,14 @@
     <script src="/snd_xplore_reporter.jsdbx"></script>
 
     <!-- CodeMirror - native scripts in ServiceNow -->
-    <script src="/codemirror.js"></script>
-    <script src="/scripts/javascript.js"></script>
+    <!--<script src="/codemirror.js"></script>-->
+    <!--<script src="/scripts/javascript.js"></script>-->
+
+    <!--CodeMirror Update-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.40.0/codemirror.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.40.0/mode/javascript/javascript.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.40.0/keymap/sublime.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.40.0/addon/comment/comment.min.js"></script>
 
     <!-- Google Code Prettify -->
     <script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>

--- a/src/UI Scripts/snd_xplore_ui.js
+++ b/src/UI Scripts/snd_xplore_ui.js
@@ -783,7 +783,8 @@ $(function () {
     indentUnit: 2,
     smartIndent: true,
     matchBrackets: true,
-    mode: 'javascript'
+    mode: 'javascript',
+    keyMap: 'sublime'
   });
 
   var sxr = snd_xplore_reporter;


### PR DESCRIPTION
No toggle comment keybinding is one of the only pain points I've had with Xplore. The native version of CodeMirror in ServiceNow is v2.21 which does not support keyMaps. This update and sublime keyMap will enable toggle comments as well as a number of  other useful keybindings:

  "Shift-Tab": "indentLess",
  "Alt-Left": "goSubwordLeft",
  "Alt-Right": "goSubwordRight",
  "Ctrl-Up": "scrollLineUp",
  "Ctrl-Down": "scrollLineDown",
  "Ctrl-L": "selectLine",
  "Shift-Ctrl-L": "splitSelectionByLine",
  "Esc": "singleSelectionTop",
  "Ctrl-Enter": "insertLineAfter",
  "Shift-Ctrl-Enter": "insertLineBefore",
  "Shift-Ctrl-Up": "swapLineUp",
  "Shift-Ctrl-Down": "swapLineDown",
  "Ctrl-/": "toggleCommentIndented",
  "Ctrl-J": "joinLines",
  "Shift-Ctrl-D": "duplicateLine",
  "F9": "sortLines",
  "Ctrl-F9": "sortLinesInsensitive",
  "Backspace": "smartBackspace",
  "Ctrl-K Ctrl-K": "delLineRight",
  "Ctrl-K Ctrl-U": "upcaseAtCursor",
  "Ctrl-K Ctrl-L": "downcaseAtCursor",
  "Ctrl-K Ctrl-C": "showInCenter",
  "Ctrl-K Ctrl-Backspace": "delLineLeft"