### PR TITLE
Allow dotwalk on attributes who's name contains dots.

### DIFF
--- a/src/Script Includes/snd_Xplore.js
+++ b/src/Script Includes/snd_Xplore.js
@@ -328,7 +328,11 @@ snd_Xplore.getLists = function () {
 snd_Xplore.dotwalk = function (obj, path) {
   // summary:
   //   Dotwalk a path on an object
-  var pathArr = path.split('.');
+  var pathArr = path.split(".").reduce(
+      function(r,c){
+            r.push(c.replace(/&#46;/g,"."));
+            return r;
+      }, []);
   var o = obj;
   for (var i = 0; i < pathArr.length; i++) {
     path = pathArr[i];

--- a/src/UI Scripts/snd_xplore_reporter.js
+++ b/src/UI Scripts/snd_xplore_reporter.js
@@ -441,7 +441,12 @@ var snd_xplore_reporter = (function () {
     };
 
     this.getBreadcrumb = function () {
-      return breadcrumbs.join('.');
+      return breadcrumbs.reduce(
+          function(r,c){
+              if (r.length > 0) r+=".";
+              r+= c.replace(/\./g,'&#46;');
+              return r;
+          },"");
     };
 
     this.clearBreadcrumb = function () {


### PR DESCRIPTION
/* Run add-hoc Server/Global script. Drill into resulting breadcrumb before and after paching. */
a={};
a['this.works'] = { "hello": "world"};
a
