### PR TITLE
Escape single quotes in generated Encoded Queries

### DIFF
--- a/src/UI Scripts/snd_xplore_shortcuts.js
+++ b/src/UI Scripts/snd_xplore_shortcuts.js
@@ -25,6 +25,8 @@ snd_xplore_shortcuts.openQuery = function openQuery() {
 	var script = 'function run() {' + newline;
 	script += '    var gr = new GlideRecord(\'' + g_list.tableName + '\');' + newline;
 	if (query) {
+		// Ensure single quotes in the query are escaped in the generated script
+		query = query.replace(/'/g, '\\\'');
 		script += '    gr.addEncodedQuery(\'' + query + '\');' + newline;
 	}
 	script += '    //gr.orderBy(\'name\');' + newline;


### PR DESCRIPTION
When an encoded query is generated containing single quotes they end the encoded query string early causing an error if you attempt to run the generated script.

An example query that caused the issue:
`gr.addEncodedQuery('sys_created_on>javascript:gs.dateGenerate('2020-01-01','00:00:00')^short_description=This ' breaks stuff');`

The above code will give you the following error due to the unescaped single quotes:
`"missing ) after argument list (<refname>; line 3): JavaScript parse error at line (3) column (72) problem = missing ) after argument list (<refname>; line 3)"`

This commit will ensure that the problematic single quotes are escaped, so generated queries can be run immediately without needing to fiddle.

The above example after implementing this fix:
`gr.addEncodedQuery('sys_created_on>javascript:gs.dateGenerate(\'2020-01-01\',\'00:00:00\')^short_description=This \' breaks nothing');`